### PR TITLE
Search for all products in vswhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "msbuild"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msbuild"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Allows builds to run msbuild for visual studio projects"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 description = "Allows builds to run msbuild for visual studio projects"
 license = "MIT"
+repository = "https://github.com/uglyoldbob/msbuild"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,14 @@ impl MsBuild {
         let output = std::process::Command::new(
             "C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vswhere.exe",
         )
-        .args(["-legacy", "-prerelease", "-format", "json"])
+        .args([
+            "-legacy",
+            "-prerelease",
+            "-format",
+            "json",
+            "-products",
+            "*",
+        ])
         .output()
         .expect("Failed to run vswhere");
         let o = std::str::from_utf8(&output.stdout).unwrap();


### PR DESCRIPTION
Hello, thank you for the useful crate!

By default, vswhere searches for Community, Professional, and Enterprise. This means it fails to find Build Tools (Microsoft.VisualStudio.Product.BuildTools, standalone MSBuild without IDE), which is frequently used in CI setting.

Additionally, bump the version because this might be a breaking change for some users.

I also added a `repository` field to `Cargo.toml` in another commit to allows crates.io and docs.rs to link back to the repository