### PR TITLE
Adds range lookup of msbuild.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,9 +9,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "lenient_semver"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de8de3f4f3754c280ce1c8c42ed8dd26a9c8385c2e5ad4ec5a77e774cea9c1ec"
+dependencies = [
+ "lenient_semver_parser",
+ "lenient_version",
+ "semver",
+]
+
+[[package]]
+name = "lenient_semver_parser"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f650c1d024ddc26b4bb79c3076b30030f2cf2b18292af698c81f7337a64d7d6"
+dependencies = [
+ "lenient_semver_version_builder",
+ "semver",
+]
+
+[[package]]
+name = "lenient_semver_version_builder"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9049f8ff49f75b946f95557148e70230499c8a642bf2d6528246afc7d0282d17"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "lenient_version"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad7b41cc0ad9b8a9f8d8fcb7c2ab6703a6da4b369cbb7e3a63ee0840769b4eb"
+dependencies = [
+ "lenient_semver_parser",
+ "lenient_semver_version_builder",
+]
+
+[[package]]
 name = "msbuild"
 version = "0.2.0"
 dependencies = [
+ "lenient_semver",
  "serde_json",
 ]
 
@@ -38,6 +79,12 @@ name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+
+[[package]]
+name = "semver"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ repository = "https://github.com/uglyoldbob/msbuild"
 
 [dependencies]
 serde_json = "1.0.115"
+lenient_semver = { version = "0.4.2", features = ["version_lite"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,75 +1,599 @@
-use std::{io::Error, num::ParseFloatError, path::PathBuf};
-
+//! # The msbuild crate
+//! This crates provides the functionality of finding
+//! the msbuild binary on the system.
+//!
+//! # Environment Variables
+//! - The `VS_WHERE_PATH` environment variable can be used in order
+//!   overwrite the default path where the crate tries to locate
+//!   the `vswhere.exe` binary.
+//!
+//! - The `VS_INSTALLATION_PATH` environment variable can be used in order
+//!   to overwrite specify a path to Visual Studio
+//!   Note! The path must still lead to a binary the fullfills the version
+//!   requirements otherwise the crate will try to probe the system
+//!   for a suitable version.
+use lenient_semver::Version;
 use serde_json::Value;
+use std::{
+    convert::TryFrom,
+    io::{Error, ErrorKind},
+    path::{Path, PathBuf},
+};
 
+/// Type for finding and interacting with the
+/// vswhere executable.
+pub struct VsWhere {
+    path: PathBuf,
+}
+
+impl VsWhere {
+    const DEFAULT_PATH: &'static str =
+        "C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vswhere.exe";
+    const ENV_KEY: &'static str = "VS_WHERE_PATH";
+    const DEFAULT_ARGS: [&'static str; 6] = [
+        "-legacy",
+        "-prerelease",
+        "-format",
+        "json",
+        "-products",
+        "*",
+    ];
+
+    /// Creates a VsWhere object if the `vswhere.exe`binary can be found.
+    pub fn find_vswhere() -> std::io::Result<Self> {
+        let path: PathBuf = VsWhere::vswhere_path();
+        if path.exists() {
+            Ok(VsWhere { path })
+        } else {
+            Err(Error::new(
+                ErrorKind::NotFound,
+                format!("The path [{}] does not exists.", path.to_string_lossy()),
+            ))
+        }
+    }
+
+    /// Runs the executable with the provided argument
+    /// or default argument if no arguments are provided.
+    pub fn run(self, args: Option<&[&str]>) -> std::io::Result<String> {
+        let command_args: &[&str] = args.unwrap_or(VsWhere::DEFAULT_ARGS.as_ref());
+        std::process::Command::new(self.path)
+            .args(command_args)
+            .output()
+            .and_then(|output: std::process::Output| {
+                std::str::from_utf8(&output.stdout).map_or_else(
+                    |e: std::str::Utf8Error| {
+                        Err(Error::new(
+                            ErrorKind::InvalidData,
+                            format!("Command output could not be parsed as UTF-8 ({}).", e),
+                        ))
+                    },
+                    |v: &str| Ok(v.to_string()),
+                )
+            })
+    }
+
+    fn vswhere_path() -> PathBuf {
+        PathBuf::from(std::env::var(VsWhere::ENV_KEY).unwrap_or(VsWhere::DEFAULT_PATH.to_string()))
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub struct InstallationVersion<'a>(Version<'a>);
+
+impl<'a> InstallationVersion<'a> {
+    pub fn parse(value: &'a str) -> std::io::Result<InstallationVersion> {
+        Version::parse(value).map_or_else(
+            |e| {
+                Err(Error::new(
+                    ErrorKind::InvalidData,
+                    format!("Failed to parse &str as a InstallationVersion: {}", e),
+                ))
+            },
+            |v| Ok(InstallationVersion(v)),
+        )
+    }
+}
+
+/// Enum holding the product line versions.
+pub enum ProductLineVersion {
+    Vs2022,
+    Vs2019,
+    Vs2017,
+}
+
+impl ProductLineVersion {
+    /// The non inclusive max installation version for a
+    /// specific product line version.
+    pub fn installation_version_max(&self) -> InstallationVersion {
+        // Constant values that are always safe to parse.
+        match self {
+            Self::Vs2022 => InstallationVersion::parse("18.0.0.0").unwrap(),
+            Self::Vs2019 => InstallationVersion::parse("17.0.0.0").unwrap(),
+            Self::Vs2017 => InstallationVersion::parse("16.0.0.0").unwrap(),
+        }
+    }
+
+    /// The inclusive min installation version for a
+    /// specific product line version.
+    pub fn installation_version_min(&self) -> InstallationVersion {
+        match self {
+            Self::Vs2022 => InstallationVersion::parse("17.0.0.0").unwrap(),
+            Self::Vs2019 => InstallationVersion::parse("16.0.0.0").unwrap(),
+            Self::Vs2017 => InstallationVersion::parse("15.0.0.0").unwrap(),
+        }
+    }
+}
+
+impl TryFrom<&str> for ProductLineVersion {
+    type Error = Error;
+
+    fn try_from(s: &str) -> std::io::Result<Self> {
+        match s {
+            "2017" => Ok(ProductLineVersion::Vs2017),
+            "2019" => Ok(ProductLineVersion::Vs2019),
+            "2022" => Ok(ProductLineVersion::Vs2022),
+            _ => Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("Product line version {} did not match any known values.", s),
+            )),
+        }
+    }
+}
+
+/// Type for finding and interactive with
+/// the msbuild executable.
 pub struct MsBuild {
     path: PathBuf,
 }
 
 impl MsBuild {
-    pub fn find_msbuild(ver: Option<&str>) -> Result<Self, std::io::Result<()>> {
-        let output = std::process::Command::new(
-            "C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vswhere.exe",
-        )
-        .args([
-            "-legacy",
-            "-prerelease",
-            "-format",
-            "json",
-            "-products",
-            "*",
-        ])
-        .output()
-        .expect("Failed to run vswhere");
-        let o = std::str::from_utf8(&output.stdout).unwrap();
-        let v: Value = serde_json::from_str(o).unwrap();
-        for c in v.as_array().unwrap().iter() {
-            let catalog = c.get("catalog").unwrap();
-            let version = catalog.get("productLineVersion").unwrap();
-            let p = c.get("installationPath").unwrap();
-            let pb: PathBuf = PathBuf::from(p.as_str().unwrap());
-            if let Some(ver) = ver {
-                if version == ver {
-                    println!("Options: {:?}", c);
-                    return Ok(Self {
-                        path: pb,
-                    });
-                }
-            } else {
-                return Ok(Self {
-                    path: pb,
-                });
-            }
-        }
-        Err(std::io::Result::Err(Error::new(std::io::ErrorKind::NotFound, "Not found")))
+    const ENV_KEY: &'static str = "VS_INSTALLATION_PATH";
+    /// Finds the msbuild executable that is associated with provided product line version
+    /// if no version is provided then the first installation of msbuild that is found
+    /// will be selected.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let product_line_version: Optional<&str> = Some("2017");
+    /// let msbuild: MsBuild = MsBuild::find_msbuild(product_line_version);
+    /// ```
+    pub fn find_msbuild(product_line_version: Option<&str>) -> std::io::Result<Self> {
+        product_line_version
+            .map(ProductLineVersion::try_from)
+            .transpose()
+            .and_then(|potential_plv| {
+                let max = potential_plv
+                    .as_ref()
+                    .map(|plv| plv.installation_version_max());
+                let min = potential_plv
+                    .as_ref()
+                    .map(|plv| plv.installation_version_min());
+                MsBuild::find_msbuild_in_range(max, min)
+            })
     }
 
-    pub fn run(&mut self, project_path: PathBuf, args: &[&str]) {
-        let mut pb = self.path.join("MsBuild");
+    /// Finds a msbuild that with the highest installation version that is in a range
+    /// between max (exclusive) and min(inclusive).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// // Find the latest supported version for msbuild
+    /// use msbuild::{MsBuild, ProductLineVersion};
+    ///
+    /// let msbuild = MsBuild::find_msbuild_in_range(
+    ///     Some(ProductLineVersion::Vs2022.installation_version_max()),
+    ///     Some(ProductLineVersion::Vs2017.installation_version_min()),
+    /// );
+    /// ```
+    pub fn find_msbuild_in_range(
+        max: Option<InstallationVersion>,
+        min: Option<InstallationVersion>,
+    ) -> std::io::Result<Self> {
+        VsWhere::find_vswhere()
+            .and_then(|vswhere| vswhere.run(None))
+            .and_then(|output| Self::parse_from_json(&output))
+            .and_then(|v: Value| {
+                Self::list_instances(&v)
+                    .and_then(|instances| Self::find_match(instances, max.as_ref(), min.as_ref()))
+            })
+            .map(|p| MsBuild {
+                path: p.as_path().join("MsBuild/Current/Bin/msbuild.exe"),
+            })
+    }
 
-        for els in std::fs::read_dir(&pb).unwrap() {
-            let name = els.unwrap().file_name();
-            let name = name.to_str().unwrap();
-            let version: Result<f32, ParseFloatError> = name.parse();
-            if version.is_ok() {
-                pb = pb.join(name);
-            }
-            if name == "Current" {
-                pb = pb.join(name);
-            }
+    /// Executes msbuild using the provided project_path and
+    /// the provided arguments.
+    pub fn run(&self, project_path: &Path, args: &[&str]) -> std::io::Result<()> {
+        if !self.path.as_path().exists() {
+            return Err(Error::new(
+                ErrorKind::NotFound,
+                format!("Could not find [{}].", self.path.to_string_lossy()),
+            ));
         }
-        let pb = pb.join("Bin");
-        let output = std::process::Command::new(pb.join("MSBuild.exe"))
+        std::process::Command::new(self.path.as_path())
             .current_dir(project_path)
             .args(args)
             .output()
-            .expect("Failed to run msbuild");
-        let o = std::str::from_utf8(&output.stdout).unwrap();
-        println!("{}", o);
-        if let Some(c) = output.status.code() {
-            if c != 0 {
-                panic!("Failed to run build {c}");
-            }
+            .and_then(|out| {
+                if out.status.success() {
+                    Ok(())
+                } else {
+                    Err(Error::new(
+                        ErrorKind::Other,
+                        format!("Failed to run msbuild: [{:?}]", out.status.code()),
+                    ))
+                }
+            })
+    }
+
+    // Internal function for parsing a string as json object.
+    fn parse_from_json(value: &str) -> std::io::Result<Value> {
+        serde_json::from_str(value).map_err(|e| {
+            Error::new(
+                ErrorKind::InvalidData,
+                format!("Failed to parse command output as json ({})", e),
+            )
+        })
+    }
+
+    // Internal function for listing the instances inthe json value.
+    fn list_instances(v: &Value) -> std::io::Result<&Vec<Value>> {
+        v.as_array().ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidData,
+                "json data did not contain any installation instances.",
+            )
+        })
+    }
+
+    // Internal function for finding the instances that matches the
+    // version range and, if specified, the path in the environment
+    // variable.
+    fn find_match(
+        instances_json: &[Value],
+        max: Option<&InstallationVersion>,
+        min: Option<&InstallationVersion>,
+    ) -> std::io::Result<PathBuf> {
+        let env_installation_path: Option<PathBuf> = std::env::var(MsBuild::ENV_KEY)
+            .ok()
+            .map(|v| PathBuf::from(&v));
+
+        // Parse the instance json data and filter result based on version.
+        let validated_instances = MsBuild::validate_instances_json(instances_json, max, min);
+
+        if let Some(specified_installation_path) = env_installation_path {
+            // Finds the specified installation path among the parsed
+            // and validated instances.
+            validated_instances
+                .iter()
+                .filter_map(|(_, p)| {
+                    if specified_installation_path.starts_with(p) {
+                        Some(p.to_path_buf())
+                    } else {
+                        None
+                    }
+                })
+                .next()
+                .ok_or(Error::new(
+                    ErrorKind::NotFound,
+                    "No instance found that matched requirements.",
+                ))
+        } else {
+            // Select the latest version.
+            validated_instances
+                .iter()
+                .max_by_key(|(v, _)| v)
+                .map(|(_, p)| p.to_path_buf())
+                .ok_or(Error::new(
+                    ErrorKind::NotFound,
+                    "No instance found that matched requirements.",
+                ))
         }
     }
+
+    /// Internal function that extracts a collection of parsed
+    /// installation instances with a version within the given
+    /// interval.
+    fn validate_instances_json<'a>(
+        instances_json: &'a [Value],
+        max: Option<&'a InstallationVersion>,
+        min: Option<&'a InstallationVersion>,
+    ) -> Vec<(InstallationVersion<'a>, &'a Path)> {
+        instances_json
+            .iter()
+            .filter_map(|i| {
+                MsBuild::parse_installation_version(i)
+                    .and_then(|installation_version| {
+                        if MsBuild::has_version_in_range(
+                            &installation_version.0,
+                            max.map(|v| &v.0),
+                            min.map(|v| &v.0),
+                        ) {
+                            MsBuild::parse_installation_path(i).map(|installation_path| {
+                                Some((installation_version, installation_path))
+                            })
+                        } else {
+                            // Maybe log(trace) that an instance was found that was not in the range.
+                            Ok(None)
+                        }
+                    })
+                    .unwrap_or_else(|e| {
+                        print!("Encounted an error during parsing of instance data: {}", e);
+                        None
+                    })
+            })
+            .collect()
+    }
+
+    fn parse_installation_path(json_value: &Value) -> std::io::Result<&Path> {
+        json_value
+            .get("installationPath")
+            .and_then(|path_json_value: &Value| path_json_value.as_str())
+            .ok_or(Error::new(
+                ErrorKind::InvalidData,
+                "Failed to retrieve `installationPath`.",
+            ))
+            .map(Path::new)
+    }
+
+    fn parse_installation_version(json_value: &Value) -> std::io::Result<InstallationVersion<'_>> {
+        json_value
+            .get("installationVersion")
+            .and_then(|version_json_value: &Value| version_json_value.as_str())
+            .and_then(|version_str: &str| Version::parse(version_str).ok())
+            .map(InstallationVersion)
+            .ok_or(Error::new(
+                ErrorKind::InvalidData,
+                "Failed to retrieve `installationVersion`.",
+            ))
+    }
+
+    /// Internal function to check if a version is in the range
+    /// if it has been specified.
+    fn has_version_in_range(
+        version: &Version,
+        max: Option<&Version>,
+        min: Option<&Version>,
+    ) -> bool {
+        let is_below_max: bool = max.map_or(true, |max_version| max_version > version);
+        let is_above_min: bool = min.map_or(true, |min_version| version >= min_version);
+        is_below_max && is_above_min
+    }
+}
+
+// ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Unit tests of the private functions and methods
+// ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+#[ignore]
+#[test]
+fn test_vswhere_find_vswhere_internal() {
+    // Cannot run the tests unless vswhere has
+    // been installed into the test environment.
+}
+
+#[test]
+fn test_msbuild_has_version_in_range() {
+    let max = Some(
+        Version::parse("4.3.2.1")
+            .expect("It should be possible to create a Version object from the string 4.3.2.1"),
+    );
+    let min = Some(
+        Version::parse("1.2.3.4")
+            .expect("It should be possible to create a Version object from the string 1.2.3.4"),
+    );
+    // Check with no min or max
+    assert!(
+        MsBuild::has_version_in_range(
+            &Version::parse("0.0.0.0")
+                .expect("It should be possible to create a Version object from the string 0.0.0.0"),
+            None,
+            None
+        ),
+        "The version 0.0.0.0 should be in range when no min or max values have been specified."
+    );
+    // Check outside of range with min value.
+    assert!(
+        !MsBuild::has_version_in_range(
+            &Version::parse("0.0.0.0")
+                .expect("It should be possible to create a Version object from the string 0.0.0.0"),
+            None,
+            min.as_ref()
+        ),
+        "The version 0.0.0.0 should not be in range when min is 1.2.3.4"
+    );
+    // Check inside of range with min value
+    assert!(
+        MsBuild::has_version_in_range(
+            &Version::parse("1.2.3.300").expect(
+                "It should be possible to create a Version object from the string 1.2.3.300"
+            ),
+            None,
+            min.as_ref()
+        ),
+        "The version 1.2.3.300 should be in range when min is 1.2.3.4 and no max is given."
+    );
+    // Check out of range with max value
+    assert!(
+        !MsBuild::has_version_in_range(
+            &Version::parse("4.3.2.11").expect(
+                "It should be possible to create a Version object from the string 4.3.2.11"
+            ),
+            max.as_ref(),
+            None,
+        ),
+        "The version 4.3.2.11 should not be in range when max is 4.3.2.1 and no min is given."
+    );
+    // Check in range with max value
+    assert!(
+        MsBuild::has_version_in_range(
+            &Version::parse("4.0.2.11").expect(
+                "It should be possible to create a Version object from the string 4.0.2.11"
+            ),
+            max.as_ref(),
+            None,
+        ),
+        "The version 4.3.2.11 should not be in range when max is 4.3.2.1 and no min is given."
+    );
+    // Check in range with min and max
+    assert!(
+        MsBuild::has_version_in_range(
+            &Version::parse("4.0.2.11").expect(
+                "It should be possible to create a Version object from the string 4.0.2.11"
+            ),
+            max.as_ref(),
+            min.as_ref(),
+        ),
+        "The version 4.3.2.11 should not be in range when max is 4.3.2.1 and no max is given."
+    );
+}
+
+#[test]
+fn test_msbuild_parse_installation_version() {
+    let version_str = "2.3.1.34";
+    let json_value = serde_json::json!({
+        "instanceId": "VisualStudio.14.0",
+        "installationPath": "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\",
+        "installationVersion": version_str
+    });
+    let expected = Version::parse(version_str)
+        .map(InstallationVersion)
+        .expect("It should be possible to parse the `version_str` as Version object.");
+    let actual = MsBuild::parse_installation_version(&json_value)
+        .expect("The function should be to extract an installation version from the json_value.");
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn test_msbuild_parse_installation_path() {
+    let expected = Path::new("C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\");
+    let json_value = serde_json::json!({
+        "instanceId": "019109ba",
+        "installDate": "2023-08-26T14:05:02Z",
+        "installationName": "VisualStudio/17.12.0+35506.116",
+        "installationPath": expected.to_string_lossy(),
+        "installationVersion": "17.12.35506.116",
+        "productId": "Microsoft.VisualStudio.Product.Community",
+        "productPath": "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\Common7\\IDE\\devenv.exe",
+    });
+    let actual = MsBuild::parse_installation_path(&json_value)
+        .expect("The function should be to extract an installation path from the json_value.");
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn test_msbuild_validate_instances_json() {
+    let json_value = serde_json::json!([
+        {
+            "installationPath": "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\",
+            "installationVersion": "14.0",
+        },
+        {
+            "installationPath": "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community",
+            "installationVersion": "17.12.35506.116",
+        },
+        {
+            "installationPath": "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise",
+            "installationVersion": "17.08.35506.116",
+        },
+    ]);
+
+    let values: &Vec<Value> = json_value
+        .as_array()
+        .expect("It should be possible to parse the json as an array of objects.");
+
+    // Sanity check.
+    assert_eq!(
+        values.len(),
+        3,
+        "There should be 3 instances: \n {:?}",
+        values
+    );
+
+    let min = Some(
+        Version::parse("17.9")
+            .map(InstallationVersion)
+            .expect("It should be possible to parse the 17.9 as a version."),
+    );
+    let max = Some(
+        Version::parse("18.0")
+            .map(InstallationVersion)
+            .expect("It should be possible to parse the 18.0 as a version."),
+    );
+    let validated_instances =
+        MsBuild::validate_instances_json(values.as_slice(), max.as_ref(), min.as_ref());
+    let expected_version = Version::parse("17.12.35506.116")
+        .map(InstallationVersion)
+        .expect("It should be possible to parse avlid version.");
+    let expected_path = Path::new("C:\\Program Files\\Microsoft Visual Studio\\2022\\Community");
+    assert_eq!(
+        validated_instances.len(),
+        1,
+        "There should only be 1 element found."
+    );
+    let (actual_version, actual_path) = validated_instances.first().unwrap();
+    assert_eq!(
+        expected_version, *actual_version,
+        "The returned version was not the expected one",
+    );
+    assert_eq!(
+        expected_path, *actual_path,
+        "The returned path was not the expected one."
+    );
+}
+
+#[test]
+fn test_msbuild_find_match() {
+    let json_value = serde_json::json!([
+        {
+            "installationPath": "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\",
+            "installationVersion": "14.0",
+        },
+        {
+            "installationPath": "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community",
+            "installationVersion": "17.12.35506.116",
+        },
+        {
+            "installationPath": "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise",
+            "installationVersion": "17.08.35506.116",
+        },
+    ]);
+
+    let values: &Vec<Value> = json_value
+        .as_array()
+        .expect("It should be possible to parse the json as an array of objects.");
+
+    // Sanity check.
+    assert_eq!(
+        values.len(),
+        3,
+        "There should be 3 instances: \n {:?}",
+        values
+    );
+
+    // The min and max are now chosen so that they will include
+    // two possible result.
+    let min = Some(
+        Version::parse("17.7")
+            .map(InstallationVersion)
+            .expect("It should be possible to parse the 17.9 as a version."),
+    );
+    let max = Some(
+        Version::parse("18.0")
+            .map(InstallationVersion)
+            .expect("It should be possible to parse the 18.0 as a version."),
+    );
+
+    // The expected values, when no environment variable have been set,
+    // is the one with the latest version.
+    let expected = PathBuf::from("C:\\Program Files\\Microsoft Visual Studio\\2022\\Community");
+
+    let actual = MsBuild::find_match(values, max.as_ref(), min.as_ref())
+        .expect("The function is expected to return a valid result.");
+
+    assert_eq!(
+        expected, actual,
+        "The resulting path does not match the expected one."
+    );
 }

--- a/tests/test_msbuild.rs
+++ b/tests/test_msbuild.rs
@@ -1,0 +1,46 @@
+use msbuild::{InstallationVersion, MsBuild, ProductLineVersion};
+
+#[ignore]
+#[test]
+fn test_find_msbuild() {
+    // This will only work if the specified version
+    // is installed in the CI environment and is recognised
+    // by vswhere.
+
+    // Find specific version 2022.
+    assert!(MsBuild::find_msbuild(Some("2022")).is_ok());
+
+    // Find any version available on the system
+    assert!(MsBuild::find_msbuild(None).is_ok());
+}
+
+#[ignore]
+#[test]
+fn test_find_msbuild_in_range_with_installed_version_in_range() {
+    // This will only work if any edition of Visual Studio 2022
+    // is installed in the CI environment.
+
+    assert!(MsBuild::find_msbuild_in_range(
+        Some(ProductLineVersion::Vs2022.installation_version_max()),
+        Some(ProductLineVersion::Vs2022.installation_version_min())
+    )
+    .is_ok());
+}
+
+#[ignore]
+#[test]
+fn test_find_msbuild_with_installed_version_out_of_range() {
+    let invalid_min: InstallationVersion = InstallationVersion::parse("1000.0.0.0")
+        .expect("Should be possible to parse valid version string");
+
+    let invalid_min_result = MsBuild::find_msbuild_in_range(None, Some(invalid_min.clone()));
+    assert!(invalid_min_result.is_err(), "Providing the function with a min version that would prevent it to find any products should result in an error.");
+
+    let invalid_max = InstallationVersion::parse("0.0.0.1")
+        .expect("Should be possible to parse valid version string");
+    let invalid_max_result = MsBuild::find_msbuild_in_range(Some(invalid_max.clone()), None);
+    assert!(invalid_max_result.is_err(), "Providing the function with a max version that would prevent it to find any products should result in an error.");
+
+    let invalid_range_result = MsBuild::find_msbuild_in_range(Some(invalid_max), Some(invalid_min));
+    assert!(invalid_range_result.is_err(), "Providing the function with a min and a max version that would prevent it to find any products should result in an error.");
+}

--- a/tests/test_vswhere.rs
+++ b/tests/test_vswhere.rs
@@ -1,0 +1,50 @@
+use msbuild::VsWhere;
+
+#[ignore]
+#[test]
+fn test_find_vswhere() {
+    // Cannot run the tests unless vswhere has
+    // been installed into the test environment.
+
+    assert!(VsWhere::find_vswhere().is_ok());
+}
+
+#[ignore]
+#[test]
+fn test_find_vswhere_env() {
+    // Cannot run this unless there is a vswhere
+    // installed in a non standard location in the
+    // test environment.
+
+    // This function is only safe to call on windows
+    // in a single threaded context. Make sure that the
+    // test environment has a vswhere.exe in the specified
+    // location.
+    const NON_STANDRAD_VSWHERE_LOCATION: &str =
+        "C:\\Program Files (x86)\\Other\\Installer\\vswhere.exe";
+    unsafe {
+        std::env::set_var("VS_WHERE_PATH", NON_STANDRAD_VSWHERE_LOCATION);
+    }
+
+    assert!(VsWhere::find_vswhere().is_ok());
+}
+
+#[ignore]
+#[test]
+fn test_run() {
+    // Cannot run the tests unless vswhere has
+    // been installed into the test environment.
+
+    let vs_where: VsWhere =
+        VsWhere::find_vswhere().expect("vswhere should have been found if it was installed.");
+
+    let args: [&str; 4] = ["-format", "json", "-products", "*"];
+    let result = vs_where
+        .run(Some(args.as_slice()))
+        .expect("Calling with vswhere with valid args should not return an error.");
+
+    assert!(
+        !result.is_empty(),
+        "The returned string from calling vswhere was empty."
+    );
+}


### PR DESCRIPTION
- Moves vswhere functionality to a sepparate struct so that it can be accessed without using MsBuild.

- Adds enum containing the currently supported product line versions.

- Adds struct representing the InstallationVersion in order to make it possible to specify a version range.

- Adds an api that takes an upper limit max (non inclusive) and a lower limit min (inclusive) in order to search for a msbuild with the latest version in that range.

- Adds the possibility to specify a different path to look for `vswhere.exe` by using the `VS_WHERE_PATH`environment variable.

- Adds the possiblity to specify a path to the msbuild, or the installtion containing the msbuild, that will be used if it fullfill the installation version requirements.