### PR TITLE
fix: pass `-utf8` flag to vswhere to ensure valid UTF-8 output

### DIFF
--- a/src/vs_where.rs
+++ b/src/vs_where.rs
@@ -15,11 +15,12 @@ impl VsWhere {
     const DEFAULT_PATH: &'static str =
         "C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vswhere.exe";
     const ENV_KEY: &'static str = "VS_WHERE_PATH";
-    const DEFAULT_ARGS: [&'static str; 6] = [
+    const DEFAULT_ARGS: [&'static str; 7] = [
         "-legacy",
         "-prerelease",
         "-format",
         "json",
+        "-utf8",
         "-products",
         "*",
     ];


### PR DESCRIPTION
On non-English Windows, `vswhere.exe` outputs localized text (e.g., `description` field) in the system's legacy encoding (GBK for Chinese, Windows-1252 for French), which causes `std::str::from_utf8` to fail.

The [`-utf8`](https://github.com/microsoft/vswhere/wiki/Encoding) flag is officially supported by vswhere and forces all output to be UTF-8 encoded, which is the cleanest fix — no information loss, no lossy conversion.

Fixes #6