### PR TITLE
Add GitHub Actions CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Test
+        run: cargo test --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Test
+        run: cargo test --verbose
+
+      - name: Publish to crates.io
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,10 +1,12 @@
+use std::path::Path;
+
 use msbuild::MsBuild;
 
 fn main() {
     let mb = MsBuild::find_msbuild(Some("2017"));
     match mb {
-        Ok(mut msb) => {
-            msb.run("./".into(), &[]);
+        Ok(msb) => {
+            let _ = msb.run(Path::new("./"), &[]);
             println!("Found msbuild");
         }
         Err(_) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub enum ProductLineVersion {
 impl ProductLineVersion {
     /// The non inclusive max installation version for a
     /// specific product line version.
-    pub fn installation_version_max(&self) -> InstallationVersion {
+    pub fn installation_version_max(&self) -> InstallationVersion<'_> {
         // Constant values that are always safe to parse.
         match self {
             Self::Vs2022 => InstallationVersion::parse("18.0.0.0").unwrap(),
@@ -67,7 +67,7 @@ impl ProductLineVersion {
 
     /// The inclusive min installation version for a
     /// specific product line version.
-    pub fn installation_version_min(&self) -> InstallationVersion {
+    pub fn installation_version_min(&self) -> InstallationVersion<'_> {
         match self {
             Self::Vs2022 => InstallationVersion::parse("17.0.0.0").unwrap(),
             Self::Vs2019 => InstallationVersion::parse("16.0.0.0").unwrap(),
@@ -179,10 +179,9 @@ impl MsBuild {
                     } else {
                         "Failed to run msbuild"
                     };
-                    Err(Error::new(
-                        ErrorKind::Other,
-                        format!("Failed to run msbuild: {error_message}"),
-                    ))
+                    Err(Error::other(format!(
+                        "Failed to run msbuild: {error_message}"
+                    )))
                 }
             })
     }
@@ -316,8 +315,8 @@ impl MsBuild {
         max: Option<&Version>,
         min: Option<&Version>,
     ) -> bool {
-        let is_below_max: bool = max.map_or(true, |max_version| max_version > version);
-        let is_above_min: bool = min.map_or(true, |min_version| version >= min_version);
+        let is_below_max: bool = max.is_none_or(|max_version| max_version > version);
+        let is_above_min: bool = min.is_none_or(|min_version| version >= min_version);
         is_below_max && is_above_min
     }
 }

--- a/src/win_sdk.rs
+++ b/src/win_sdk.rs
@@ -148,7 +148,7 @@ impl WinSdk {
     }
 
     /// Creates a map that maps SDK versions to directories.
-    fn versioned_directory_map(version_dirs: &[PathBuf]) -> BTreeMap<WinSdkVersion, &PathBuf> {
+    fn versioned_directory_map(version_dirs: &[PathBuf]) -> BTreeMap<WinSdkVersion<'_>, &PathBuf> {
         version_dirs
             .iter()
             .map(|d| {
@@ -208,9 +208,7 @@ impl WinSdk {
         path.file_name()
             .and_then(|ver_dir| ver_dir.to_str())
             .and_then(|ver_dir_str| WinSdkVersion::parse(ver_dir_str).ok())
-            .map_or(false, |win_sdk_ver| {
-                Self::has_version_in_range(&win_sdk_ver, max, min)
-            })
+            .is_some_and(|win_sdk_ver| Self::has_version_in_range(&win_sdk_ver, max, min))
     }
 
     fn installation_folder() -> std::io::Result<PathBuf> {
@@ -259,8 +257,8 @@ impl WinSdk {
         max: Option<&WinSdkVersion>,
         min: Option<&WinSdkVersion>,
     ) -> bool {
-        let is_below_max: bool = max.map_or(true, |max_version| max_version > version);
-        let is_above_min: bool = min.map_or(true, |min_version| version >= min_version);
+        let is_below_max: bool = max.is_none_or(|max_version| max_version > version);
+        let is_above_min: bool = min.is_none_or(|min_version| version >= min_version);
         is_below_max && is_above_min
     }
 }


### PR DESCRIPTION
## Summary
- Add CI workflow (`.github/workflows/ci.yml`) that runs on push/PR to `main`: checks formatting (`cargo fmt`), linting (`cargo clippy`), build, and tests on `windows-latest`
- Add release workflow (`.github/workflows/release.yml`) that publishes to crates.io when a version tag (`v*`) is pushed — requires a `CARGO_REGISTRY_TOKEN` repository secret
- Fix existing clippy warnings (`map_or` → `is_none_or`/`is_some_and`, elided lifetime annotations, `Error::other`)
- Fix compilation error in `examples/main.rs`

## Release usage
To publish a new release:
1. Update the version in `Cargo.toml`
2. Commit and push to `main`
3. Create and push a tag: `git tag v0.2.1 && git push origin v0.2.1`
4. The release workflow will automatically publish to crates.io

> **Note:** You need to add a `CARGO_REGISTRY_TOKEN` secret in the repository settings (Settings → Secrets → Actions) with your crates.io API token.