### PR TITLE
feat: add Visual Studio 2026 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
@@ -25,10 +24,13 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Build
         run: cargo build --verbose
 
       - name: Test
         run: cargo test --verbose
+
+      - name: Test VS2022
+        run: cargo test --features has-vs2022 --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ winreg = { version = "0.55" }
 
 [dev-dependencies]
 tempfile = "3.19.1"
+
+[features]
+has-vs2022 = []
+has-vs2026 = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ impl<'a> InstallationVersion<'a> {
 
 /// Enum holding the product line versions.
 pub enum ProductLineVersion {
+    Vs2026,
     Vs2022,
     Vs2019,
     Vs2017,
@@ -59,6 +60,7 @@ impl ProductLineVersion {
     pub fn installation_version_max(&self) -> InstallationVersion<'_> {
         // Constant values that are always safe to parse.
         match self {
+            Self::Vs2026 => InstallationVersion::parse("19.0.0.0").unwrap(),
             Self::Vs2022 => InstallationVersion::parse("18.0.0.0").unwrap(),
             Self::Vs2019 => InstallationVersion::parse("17.0.0.0").unwrap(),
             Self::Vs2017 => InstallationVersion::parse("16.0.0.0").unwrap(),
@@ -69,6 +71,7 @@ impl ProductLineVersion {
     /// specific product line version.
     pub fn installation_version_min(&self) -> InstallationVersion<'_> {
         match self {
+            Self::Vs2026 => InstallationVersion::parse("18.0.0.0").unwrap(),
             Self::Vs2022 => InstallationVersion::parse("17.0.0.0").unwrap(),
             Self::Vs2019 => InstallationVersion::parse("16.0.0.0").unwrap(),
             Self::Vs2017 => InstallationVersion::parse("15.0.0.0").unwrap(),
@@ -84,6 +87,7 @@ impl TryFrom<&str> for ProductLineVersion {
             "2017" => Ok(ProductLineVersion::Vs2017),
             "2019" => Ok(ProductLineVersion::Vs2019),
             "2022" => Ok(ProductLineVersion::Vs2022),
+            "2026" => Ok(ProductLineVersion::Vs2026),
             _ => Err(Error::new(
                 ErrorKind::InvalidData,
                 format!("Product line version {} did not match any known values.", s),
@@ -106,9 +110,9 @@ impl MsBuild {
     ///
     /// # Examples
     ///
-    /// ```
-    /// let product_line_version: Optional<&str> = Some("2017");
-    /// let msbuild: MsBuild = MsBuild::find_msbuild(product_line_version);
+    /// ```no_run
+    /// let product_line_version: Option<&str> = Some("2017");
+    /// let msbuild = msbuild::MsBuild::find_msbuild(product_line_version);
     /// ```
     pub fn find_msbuild(product_line_version: Option<&str>) -> std::io::Result<Self> {
         product_line_version

--- a/tests/test_msbuild.rs
+++ b/tests/test_msbuild.rs
@@ -1,25 +1,15 @@
 use msbuild::{InstallationVersion, MsBuild, ProductLineVersion};
 
-#[ignore]
+#[cfg_attr(not(feature = "has-vs2022"), ignore)]
 #[test]
-fn test_find_msbuild() {
-    // This will only work if the specified version
-    // is installed in the CI environment and is recognised
-    // by vswhere.
-
-    // Find specific version 2022.
+fn test_find_msbuild_vs2022() {
     assert!(MsBuild::find_msbuild(Some("2022")).is_ok());
-
-    // Find any version available on the system
     assert!(MsBuild::find_msbuild(None).is_ok());
 }
 
-#[ignore]
+#[cfg_attr(not(feature = "has-vs2022"), ignore)]
 #[test]
-fn test_find_msbuild_in_range_with_installed_version_in_range() {
-    // This will only work if any edition of Visual Studio 2022
-    // is installed in the CI environment.
-
+fn test_find_msbuild_in_range_vs2022() {
     assert!(MsBuild::find_msbuild_in_range(
         Some(ProductLineVersion::Vs2022.installation_version_max()),
         Some(ProductLineVersion::Vs2022.installation_version_min())
@@ -27,7 +17,24 @@ fn test_find_msbuild_in_range_with_installed_version_in_range() {
     .is_ok());
 }
 
-#[ignore]
+#[cfg_attr(not(feature = "has-vs2026"), ignore)]
+#[test]
+fn test_find_msbuild_vs2026() {
+    assert!(MsBuild::find_msbuild(Some("2026")).is_ok());
+    assert!(MsBuild::find_msbuild(None).is_ok());
+}
+
+#[cfg_attr(not(feature = "has-vs2026"), ignore)]
+#[test]
+fn test_find_msbuild_in_range_vs2026() {
+    assert!(MsBuild::find_msbuild_in_range(
+        Some(ProductLineVersion::Vs2026.installation_version_max()),
+        Some(ProductLineVersion::Vs2026.installation_version_min())
+    )
+    .is_ok());
+}
+
+#[cfg_attr(not(any(feature = "has-vs2022", feature = "has-vs2026")), ignore)]
 #[test]
 fn test_find_msbuild_with_installed_version_out_of_range() {
     let invalid_min: InstallationVersion = InstallationVersion::parse("1000.0.0.0")

--- a/tests/test_vswhere.rs
+++ b/tests/test_vswhere.rs
@@ -1,6 +1,6 @@
 use msbuild::VsWhere;
 
-#[ignore]
+#[cfg_attr(not(feature = "has-vs2022"), ignore)]
 #[test]
 fn test_find_vswhere() {
     // Cannot run the tests unless vswhere has
@@ -29,7 +29,7 @@ fn test_find_vswhere_env() {
     assert!(VsWhere::find_vswhere().is_ok());
 }
 
-#[ignore]
+#[cfg_attr(not(feature = "has-vs2022"), ignore)]
 #[test]
 fn test_run() {
     // Cannot run the tests unless vswhere has


### PR DESCRIPTION
## Summary
- Add `Vs2026` variant to `ProductLineVersion` with installation version range `[18.0, 19.0)`
- Support `"2026"` string in `ProductLineVersion::try_from`
- Add `has-vs2022` / `has-vs2026` cargo features to gate integration tests
  - `#[ignore]` → `#[cfg_attr(not(feature = "has-vs20xx"), ignore)]`
  - Local `cargo test` skips integration tests by default
  - CI runs `cargo test --features has-vs2022` to enable VS2022 integration tests
- Update CI: clippy checks all features, split test steps (Test + Test VS2022)
- Fix doc test (`Optional` -> `Option`, mark as `no_run`)

## Usage
```sh
# Local: skip integration tests
cargo test

# CI or local with VS 2022 installed
cargo test --features has-vs2022

# Local with VS 2026 installed
cargo test --features has-vs2026
```