### PR TITLE
refactor(test): replace feature flags with #[ignore] and runtime VS detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,27 @@ jobs:
       - name: Test
         run: cargo test --verbose
 
-      - name: Test VS2022
-        run: cargo test --features has-vs2022 --verbose
+      - name: Test Visual Studio integration
+        shell: pwsh
+        run: |
+          $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+          $instances = & $vswhere -utf8 -format json -products * | ConvertFrom-Json
+          $productLineVersions = @($instances | ForEach-Object { $_.catalog.productLineVersion } | Where-Object { $_ })
+          $supportedVersions = @($productLineVersions | Where-Object { $_ -in @('2022', '2026') } | Select-Object -Unique)
+
+          if ($supportedVersions.Count -eq 0) {
+            throw 'No supported Visual Studio installation found for integration tests.'
+          }
+
+          if ($supportedVersions -contains '2022') {
+            cargo test --test test_msbuild vs2022 --verbose -- --ignored
+          }
+
+          if ($supportedVersions -contains '2026') {
+            cargo test --test test_msbuild vs2026 --verbose -- --ignored
+          }
+
+          cargo test --test test_msbuild test_find_msbuild_with_installed_version_out_of_range --verbose -- --ignored
+
+      - name: Test vswhere integration
+        run: cargo test --test test_vswhere --verbose -- --ignored --skip test_find_vswhere_env

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,3 @@ winreg = { version = "0.55" }
 
 [dev-dependencies]
 tempfile = "3.19.1"
-
-[features]
-has-vs2022 = []
-has-vs2026 = []

--- a/tests/test_msbuild.rs
+++ b/tests/test_msbuild.rs
@@ -1,13 +1,13 @@
 use msbuild::{InstallationVersion, MsBuild, ProductLineVersion};
 
-#[cfg_attr(not(feature = "has-vs2022"), ignore)]
+#[ignore = "requires Visual Studio 2022 in the test environment"]
 #[test]
 fn test_find_msbuild_vs2022() {
     assert!(MsBuild::find_msbuild(Some("2022")).is_ok());
     assert!(MsBuild::find_msbuild(None).is_ok());
 }
 
-#[cfg_attr(not(feature = "has-vs2022"), ignore)]
+#[ignore = "requires Visual Studio 2022 in the test environment"]
 #[test]
 fn test_find_msbuild_in_range_vs2022() {
     assert!(MsBuild::find_msbuild_in_range(
@@ -17,14 +17,14 @@ fn test_find_msbuild_in_range_vs2022() {
     .is_ok());
 }
 
-#[cfg_attr(not(feature = "has-vs2026"), ignore)]
+#[ignore = "requires Visual Studio 2026 in the test environment"]
 #[test]
 fn test_find_msbuild_vs2026() {
     assert!(MsBuild::find_msbuild(Some("2026")).is_ok());
     assert!(MsBuild::find_msbuild(None).is_ok());
 }
 
-#[cfg_attr(not(feature = "has-vs2026"), ignore)]
+#[ignore = "requires Visual Studio 2026 in the test environment"]
 #[test]
 fn test_find_msbuild_in_range_vs2026() {
     assert!(MsBuild::find_msbuild_in_range(
@@ -34,7 +34,7 @@ fn test_find_msbuild_in_range_vs2026() {
     .is_ok());
 }
 
-#[cfg_attr(not(any(feature = "has-vs2022", feature = "has-vs2026")), ignore)]
+#[ignore = "requires a Visual Studio installation in the test environment"]
 #[test]
 fn test_find_msbuild_with_installed_version_out_of_range() {
     let invalid_min: InstallationVersion = InstallationVersion::parse("1000.0.0.0")

--- a/tests/test_vswhere.rs
+++ b/tests/test_vswhere.rs
@@ -1,6 +1,6 @@
 use msbuild::VsWhere;
 
-#[cfg_attr(not(feature = "has-vs2022"), ignore)]
+#[ignore = "requires vswhere.exe in the test environment"]
 #[test]
 fn test_find_vswhere() {
     // Cannot run the tests unless vswhere has
@@ -9,7 +9,7 @@ fn test_find_vswhere() {
     assert!(VsWhere::find_vswhere().is_ok());
 }
 
-#[ignore]
+#[ignore = "requires VS_WHERE_PATH to point to a non-standard vswhere.exe fixture"]
 #[test]
 fn test_find_vswhere_env() {
     // Cannot run this unless there is a vswhere
@@ -29,7 +29,7 @@ fn test_find_vswhere_env() {
     assert!(VsWhere::find_vswhere().is_ok());
 }
 
-#[cfg_attr(not(feature = "has-vs2022"), ignore)]
+#[ignore = "requires vswhere.exe in the test environment"]
 #[test]
 fn test_run() {
     // Cannot run the tests unless vswhere has
@@ -38,7 +38,7 @@ fn test_run() {
     let vs_where: VsWhere =
         VsWhere::find_vswhere().expect("vswhere should have been found if it was installed.");
 
-    let args: [&str; 4] = ["-format", "json", "-products", "*"];
+    let args: [&str; 5] = ["-utf8", "-format", "json", "-products", "*"];
     let result = vs_where
         .run(Some(args.as_slice()))
         .expect("Calling with vswhere with valid args should not return an error.");


### PR DESCRIPTION
## Summary

- Remove `has-vs2022` / `has-vs2026` cargo feature flags from `Cargo.toml`
- Replace `#[cfg_attr(not(feature = "..."), ignore)]` with unconditional `#[ignore = "reason"]` on all integration tests
- CI now uses `vswhere` to dynamically detect installed Visual Studio versions and selectively runs the corresponding integration tests

## Why not feature flags?

Using cargo feature flags to gate integration tests has several drawbacks:

1. **Feature flags are meant for conditional compilation of library code**, not for toggling tests based on the runtime environment. Using them this way is a misuse of the feature system.
2. **Consumers of the crate see these features.** `has-vs2022` / `has-vs2026` appear in `cargo doc`, on crates.io, and in dependency resolution — but they are meaningless outside of CI, which is confusing.
3. **Hard-coded CI assumptions.** The old CI step (`cargo test --features has-vs2022`) assumed VS2022 was always installed on the runner. If the runner image changes, CI silently runs the wrong tests or fails unexpectedly.
4. **Adding a new VS version requires touching multiple places:** `Cargo.toml` (new feature), test files (new `cfg_attr`), and CI (new step) — all tightly coupled.

The new approach uses `#[ignore]` (the idiomatic Rust mechanism for environment-dependent tests) and a CI script that queries the actual environment at runtime, making the setup more robust and self-describing.

## Test plan

- [x] `cargo test` passes — all integration tests are correctly ignored with descriptive reasons
- [x] `cargo test --test test_msbuild vs2022 -- --ignored` runs only VS2022 tests
- [x] `cargo test --test test_vswhere -- --ignored --skip test_find_vswhere_env` runs vswhere tests
- [x] No remaining references to `has-vs2022` / `has-vs2026` in the codebase